### PR TITLE
feat: add multi-display cursor script and docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,31 +4,42 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a Hammerspoon configuration project that provides multi-display cursor movement functionality for macOS. Users can press Cmd+Ctrl+[1-9] to instantly move their cursor to the center of the corresponding display.
+This is a Hammerspoon configuration project that provides multi-display cursor movement functionality for macOS. Users can press Cmd+Shift+Ctrl+[1-9] to instantly move their cursor to the center of the corresponding display, or use arrow keys for sequential navigation.
 
 ## Development Setup
 
-1. **Installation**: Copy `init.lua` to `~/.hammerspoon/` directory
+1. **Installation**: Create directory if needed and copy file: `mkdir -p ~/.hammerspoon && cp init.lua ~/.hammerspoon/`
 2. **Reload Configuration**: Use Hammerspoon's reload feature or restart the application
-3. **Testing**: Connect multiple displays and test hotkeys Cmd+Ctrl+[1-9]
+3. **Testing**: Connect multiple displays and test hotkeys
 
 ## Code Architecture
 
-The project consists of a single `init.lua` file that:
-- Creates 9 hotkey bindings (Cmd+Ctrl+1 through Cmd+Ctrl+9)
-- Each hotkey moves the cursor to the center of the corresponding display number
-- Validates display existence and skips movement if already on target display
-- Shows user alerts for invalid display numbers
+The `init.lua` file follows a modular structure:
+
+### Configuration
+- `HOTKEY_MODS` constant defines the modifier keys (currently `{"cmd", "shift", "ctrl"}`)
+
+### Helper Functions
+- `moveToScreenCenter(screen)` - Moves cursor to center of given screen
+- `moveToDisplay(displayNumber)` - Handles direct display selection with validation
+- `moveToNextDisplay()` - Navigates to next display in sequence
+- `moveToPreviousDisplay()` - Navigates to previous display in sequence
+
+### Hotkey Bindings
+- Number keys (1-9) for direct display selection
+- Arrow keys (left/right) for sequential navigation
 
 ## Key Implementation Details
 
 - Uses `hs.screen.allScreens()` to get all connected displays
-- Uses `hs.mouse.getAbsolutePosition()` to get current cursor position
-- Uses `hs.screen.find()` to identify current screen from cursor position
-- Moves cursor with `hs.mouse.setAbsolutePosition()` to screen center
+- Uses `hs.mouse.getCurrentScreen()` to identify current screen
+- Uses `hs.geometry.rectMidPoint()` for calculating screen centers
+- Uses `screen:next()` and `screen:previous()` for sequential navigation
+- Moves cursor with `hs.mouse.setAbsolutePosition()`
 
 ## Common Tasks
 
-- **Add new hotkey combinations**: Modify the `hs.hotkey.bind` parameters in init.lua
-- **Change cursor destination**: Modify the calculation in `targetScreen:absoluteToLocal(targetScreen:frame().center)`
-- **Add more display support**: Extend the loop beyond 9 if needed
+- **Change hotkey combination**: Modify the `HOTKEY_MODS` variable
+- **Change cursor destination**: Modify the `moveToScreenCenter()` function
+- **Add more display support**: Change the loop limit in hotkey bindings section
+- **Add new navigation methods**: Create new helper functions and bind them to hotkeys

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,34 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Hammerspoon configuration project that provides multi-display cursor movement functionality for macOS. Users can press Cmd+Ctrl+[1-9] to instantly move their cursor to the center of the corresponding display.
+
+## Development Setup
+
+1. **Installation**: Copy `init.lua` to `~/.hammerspoon/` directory
+2. **Reload Configuration**: Use Hammerspoon's reload feature or restart the application
+3. **Testing**: Connect multiple displays and test hotkeys Cmd+Ctrl+[1-9]
+
+## Code Architecture
+
+The project consists of a single `init.lua` file that:
+- Creates 9 hotkey bindings (Cmd+Ctrl+1 through Cmd+Ctrl+9)
+- Each hotkey moves the cursor to the center of the corresponding display number
+- Validates display existence and skips movement if already on target display
+- Shows user alerts for invalid display numbers
+
+## Key Implementation Details
+
+- Uses `hs.screen.allScreens()` to get all connected displays
+- Uses `hs.mouse.getAbsolutePosition()` to get current cursor position
+- Uses `hs.screen.find()` to identify current screen from cursor position
+- Moves cursor with `hs.mouse.setAbsolutePosition()` to screen center
+
+## Common Tasks
+
+- **Add new hotkey combinations**: Modify the `hs.hotkey.bind` parameters in init.lua
+- **Change cursor destination**: Modify the calculation in `targetScreen:absoluteToLocal(targetScreen:frame().center)`
+- **Add more display support**: Extend the loop beyond 9 if needed

--- a/README.md
+++ b/README.md
@@ -1,1 +1,46 @@
 # hammerspoon-multi-display-cursor
+
+Move cursor across multiple displays using keyboard shortcuts.
+
+## Features
+
+- `Cmd+Shift+Ctrl+[1-9]` to jump to display 1-9
+- `Cmd+Shift+Ctrl+←/→` to navigate between displays sequentially
+- Cursor moves to center of target display
+- Skips if already on target display
+- Shows alert for non-existent displays
+
+## Installation
+
+```bash
+mkdir -p ~/.hammerspoon
+
+cp init.lua ~/.hammerspoon/
+```
+
+## Usage
+
+### Direct Display Selection
+- `Cmd+Shift+Ctrl+1` → Display 1
+- `Cmd+Shift+Ctrl+2` → Display 2
+- `Cmd+Shift+Ctrl+3` → Display 3
+- ... up to Display 9
+
+### Sequential Navigation
+- `Cmd+Shift+Ctrl+→` → Next display
+- `Cmd+Shift+Ctrl+←` → Previous display
+
+## Customization
+
+Edit `init.lua` to:
+- Change hotkey combination (modify `HOTKEY_MODS` variable)
+- Change cursor target position
+- Support more than 9 displays
+
+## License
+
+MIT License
+
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.

--- a/init.lua
+++ b/init.lua
@@ -14,7 +14,6 @@ local function moveToDisplay(displayNumber)
   local screens = hs.screen.allScreens()
   
   if displayNumber < 1 or displayNumber > #screens then
-    hs.alert.show("Display " .. displayNumber .. " not found")
     return
   end
   

--- a/init.lua
+++ b/init.lua
@@ -1,0 +1,57 @@
+-- Configuration
+local HOTKEY_MODS = { "cmd", "shift", "ctrl" }
+
+-- Helper functions
+local function moveToScreenCenter(screen)
+  if not screen then return false end
+  
+  local center = hs.geometry.rectMidPoint(screen:fullFrame())
+  hs.mouse.setAbsolutePosition(center)
+  return true
+end
+
+local function moveToDisplay(displayNumber)
+  local screens = hs.screen.allScreens()
+  
+  if displayNumber > #screens then
+    hs.alert.show("Display " .. displayNumber .. " not found")
+    return
+  end
+  
+  local targetScreen = screens[displayNumber]
+  local currentScreen = hs.mouse.getCurrentScreen()
+  
+  if currentScreen ~= targetScreen then
+    moveToScreenCenter(targetScreen)
+  end
+end
+
+local function moveToNextDisplay()
+  local current = hs.mouse.getCurrentScreen()
+  local next = current:next()
+  
+  if next and next ~= current then
+    moveToScreenCenter(next)
+  end
+end
+
+local function moveToPreviousDisplay()
+  local current = hs.mouse.getCurrentScreen()
+  local prev = current:previous()
+  
+  if prev and prev ~= current then
+    moveToScreenCenter(prev)
+  end
+end
+
+-- Hotkey bindings
+-- Number keys for direct display selection
+for i = 1, 9 do
+  hs.hotkey.bind(HOTKEY_MODS, tostring(i), function()
+    moveToDisplay(i)
+  end)
+end
+
+-- Arrow keys for sequential navigation
+hs.hotkey.bind(HOTKEY_MODS, "right", moveToNextDisplay)
+hs.hotkey.bind(HOTKEY_MODS, "left", moveToPreviousDisplay)

--- a/init.lua
+++ b/init.lua
@@ -13,7 +13,7 @@ end
 local function moveToDisplay(displayNumber)
   local screens = hs.screen.allScreens()
   
-  if displayNumber > #screens then
+  if displayNumber < 1 or displayNumber > #screens then
     hs.alert.show("Display " .. displayNumber .. " not found")
     return
   end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts (Cmd+Shift+Ctrl+[1-9]) to instantly move the mouse cursor to the center of the selected display on macOS with Hammerspoon.
  * Added sequential navigation between displays using Cmd+Shift+Ctrl+left/right arrow keys.

* **Documentation**
  * Introduced comprehensive setup and usage instructions, feature descriptions, customization tips, and contribution guidelines in the documentation.
  * Added detailed guidance for using and extending the multi-display cursor movement configuration with Claude Code integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->