### PR TITLE
feat: 🎸 Remember last cursor position per display

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ For Hammerspoon installation and usage, please refer to: https://github.com/Hamm
 
 - `Cmd+Shift+Ctrl+[1-9]` to jump to display 1-9
 - `Cmd+Shift+Ctrl+←/→` to navigate between displays sequentially
-- Cursor moves to center of target display
+- Remembers and restores last cursor position for each display
+- Falls back to center of display if no previous position exists
 - Automatically activates the most recently used window on target display
 - Skips if already on target display
 - Shows alert for non-existent displays

--- a/init.lua
+++ b/init.lua
@@ -1,7 +1,34 @@
 -- Configuration
 local HOTKEY_MODS = { "cmd", "shift", "ctrl" }
 
+-- Store cursor positions for each screen
+local cursorPositions = {}
+
 -- Helper functions
+local function saveCursorPosition(screen)
+  if not screen then return end
+  
+  local screenId = screen:getUUID()
+  local currentPos = hs.mouse.absolutePosition()
+  cursorPositions[screenId] = currentPos
+end
+
+local function restoreCursorPosition(screen)
+  if not screen then return false end
+  
+  local screenId = screen:getUUID()
+  local savedPos = cursorPositions[screenId]
+  
+  if savedPos then
+    hs.mouse.setAbsolutePosition(savedPos)
+    return true
+  else
+    local center = hs.geometry.rectMidPoint(screen:fullFrame())
+    hs.mouse.setAbsolutePosition(center)
+    return false
+  end
+end
+
 local function activateLastAppOnScreen(screen)
   if not screen then return false end
   
@@ -18,11 +45,18 @@ local function activateLastAppOnScreen(screen)
   return false
 end
 
-local function moveToScreenCenter(screen)
+local function moveToScreen(screen)
   if not screen then return false end
   
-  local center = hs.geometry.rectMidPoint(screen:fullFrame())
-  hs.mouse.setAbsolutePosition(center)
+  local currentScreen = hs.mouse.getCurrentScreen()
+  
+  -- Save cursor position on current screen before moving
+  if currentScreen and currentScreen ~= screen then
+    saveCursorPosition(currentScreen)
+  end
+  
+  -- Restore cursor position on target screen
+  restoreCursorPosition(screen)
   
   activateLastAppOnScreen(screen)
   
@@ -40,7 +74,7 @@ local function moveToDisplay(displayNumber)
   local currentScreen = hs.mouse.getCurrentScreen()
   
   if currentScreen ~= targetScreen then
-    moveToScreenCenter(targetScreen)
+    moveToScreen(targetScreen)
   end
 end
 
@@ -49,7 +83,7 @@ local function moveToNextDisplay()
   local next = current:next()
   
   if next and next ~= current then
-    moveToScreenCenter(next)
+    moveToScreen(next)
   end
 end
 
@@ -58,7 +92,7 @@ local function moveToPreviousDisplay()
   local prev = current:previous()
   
   if prev and prev ~= current then
-    moveToScreenCenter(prev)
+    moveToScreen(prev)
   end
 end
 


### PR DESCRIPTION
closes #5 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The cursor now remembers and restores its last position on each display when switching between screens, improving navigation. If no previous position is available, the cursor defaults to the center of the screen.

* **Documentation**
  * Updated the README to clarify the new cursor behavior when moving between displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->